### PR TITLE
Address jest tests hanging on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           command: bundle exec rspec
       - run:
           name: Jest
-          command: yarn test
+          command: yarn test --maxWorkers=2
 
       - run:
           name: Node coverage


### PR DESCRIPTION
According to the internet, this change should prevent circleci from hanging (and subsequently failing) when running jest tests